### PR TITLE
Fix config.toml enter_accept comment for default value

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -145,8 +145,8 @@
 ## 5. Stripe live/test keys
 # secrets_filter = true
 
-## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command. Press tab to return to the shell and edit.
-# This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
+## Defaults to false. If enabled, upon hitting enter Atuin will immediately execute the command. Press tab to return to the shell and edit.
+# This "true" applies for new installs, old installs will keep the old ("false") behaviour unless configured otherwise.
 enter_accept = true
 
 ## Defaults to "emacs".  This specifies the keymap on the startup of `atuin


### PR DESCRIPTION
This PR addresses a very minor comment in the default `config.toml`, which says that the `enter_accept` config option "`Defaults to true`" when the `atuin` binary actually defaults to `false` if the option is not present / commented out. 

That comment confused me (I commented out the seemingly unnecessary line) because most comments like that one—including throughout the rest of this file—use "default" to describe what the code does if the option is not present (i.e. if it's commented out in this file).

Happy to reword as needed (or, feel free). I'm sure it can be improved.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
